### PR TITLE
Retorno da visualização de impressão do DANFE da NF-e A4

### DIFF
--- a/NFe.Danfe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.Danfe.AppTeste/MainWindow.xaml.cs
@@ -223,9 +223,9 @@ namespace NFe.Danfe.AppTeste
                                     desenvolvedor: "NOME DA SOFTWARE HOUSE",
                                     arquivoRelatorio: string.Empty);
 
-                //danfe.Visualizar();
+                danfe.Visualizar();
                 //danfe.Imprimir();
-                danfe.ExibirDesign();
+                //danfe.ExibirDesign();
                 //danfe.ExportarPdf(@"d:\teste.pdf");
 
                 #endregion

--- a/Shared.NFe.Danfe.Fast/DanfeSharedHelper.cs
+++ b/Shared.NFe.Danfe.Fast/DanfeSharedHelper.cs
@@ -45,7 +45,11 @@ namespace Shared.DFe.Danfe.Fast
             //alteracao necessaria para .netstandard, o código abaixo utiliza um método onde não é compativel para .netstandard:
             //de : //((PictureObject)relatorio.FindObject("poEmitLogo")).Image = configuracaoDanfeNfce.ObterLogo();
             //para:
+#if Standard
             ((PictureObject)relatorio.FindObject("poEmitLogo")).SetImageData(configuracaoDanfeNfce.Logomarca);
+#else
+            ((PictureObject)relatorio.FindObject("poEmitLogo")).Image = configuracaoDanfeNfce.ObterLogo();
+#endif
 
             ((TextObject)relatorio.FindObject("txtUrl")).Text = string.IsNullOrEmpty(proc.NFe.infNFeSupl.urlChave) ? proc.NFe.infNFeSupl.ObterUrlConsulta(proc.NFe, configuracaoDanfeNfce.VersaoQrCode) : proc.NFe.infNFeSupl.urlChave;
             ((BarcodeObject)relatorio.FindObject("bcoQrCode")).Text = proc.NFe.infNFeSupl == null ? proc.NFe.infNFeSupl.ObterUrlQrCode(proc.NFe, configuracaoDanfeNfce.VersaoQrCode, cIdToken, csc) : proc.NFe.infNFeSupl.qrCode;

--- a/Shared.NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
+++ b/Shared.NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
@@ -386,6 +386,14 @@ namespace NFe.Utils.InformacoesSuplementares
         /// </summary>
         public static string ObterUrlQrCode(this infNFeSupl infNFeSupl, Classes.NFe nfe, VersaoQrCode versaoQrCode, string cIdToken, string csc)
         {
+            Func<string, string> msgErro = parametro => $"O {parametro} não foi informado!";
+
+            if (string.IsNullOrEmpty(cIdToken))
+                throw new ArgumentNullException(nameof(cIdToken), msgErro("token"));
+
+            if (string.IsNullOrEmpty(csc))
+                throw new ArgumentNullException(nameof(cIdToken), msgErro("CSC"));
+
             var versaoServico = Conversao.StringParaVersaoServico(nfe.infNFe.versao);
             switch (versaoQrCode)
             {


### PR DESCRIPTION
método Ne.Danfe.AppTeste.MainWindow.BtnNfeDanfeA4_Click;

Adicionada diretiva de compilação para o .net Standard na classe Shared.DFe.Danfe.Fast.DanfeSharedHelper;
Adicionada checagem do token e do CSC em NFe.Utils.InformacoesSuplementares.ExtinfNFeSupl.ObterUrlQrCode.