### PR TITLE
Adicionado atributo que estava faltando no "categCombVeic" para MDF-e

### DIFF
--- a/Shared.MDFe.Classes/Informacoes/categCombVeic.cs
+++ b/Shared.MDFe.Classes/Informacoes/categCombVeic.cs
@@ -30,5 +30,8 @@ namespace MDFe.Classes.Informacoes
 
         [XmlEnum("13")]
         VeiculoComercial10Eixos = 10,
+
+        [XmlEnum("14")]
+        VeiculoComercialAcimaDe10Eixos = 14
     }
 }


### PR DESCRIPTION
MDFe_Nota_Tecnica_2021_001_v1.02.pdf
Página 7