### PR TITLE
Update NFeRetrato.frx

### DIFF
--- a/NFe.Danfe.Base/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Base/NFe/NFeRetrato.frx
@@ -283,10 +283,13 @@ namespace FastReport
       {
         if(ipiBasico == null)
         {
-          var ipiDevolvidoPercentual = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.impostoDevol.pDevol&quot;)) ?? 0M;
+          var DevolvidoPercentual = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.impostoDevol.pDevol&quot;)) ?? 0M;
           var ipiDevolvidoValor = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.impostoDevol.IPI.vIPIDevol&quot;)) ?? 0M;
-          prodAlqIPICell.Text = FormatNumber(ipiDevolvidoPercentual,2);
           prodIPICell.Text = FormatNumber(ipiDevolvidoValor,2);
+	  if(ipiDevolvidoValor > 0)
+	  {
+            prodAlqIPICell.Text = FormatNumber(DevolvidoPercentual,2);
+	  }
         }
       }	  
     }


### PR DESCRIPTION
pDevol nao representa % ipi devolvido e sim o Percentual da mercadoria devolvida (O valor máximo deste percentual é 100%, no 
caso de devolução total da mercadoria.)