### PR TITLE
URL sefaz RS cte v4 nao informada (#1480)

### DIFF
--- a/CTe.AppTeste/CTeTesteModel.cs
+++ b/CTe.AppTeste/CTeTesteModel.cs
@@ -1519,6 +1519,14 @@ namespace CTe.AppTeste
             cteOS.InfCte.vPrest = new vPrestOs();
             cteOS.InfCte.vPrest.vTPrest = 100m;
             cteOS.InfCte.vPrest.vRec = 100m;
+            cteOS.InfCte.vPrest.Comp = new List<Classes.Informacoes.Complemento.Comp>()
+            {
+                new Classes.Informacoes.Complemento.Comp()
+                {
+                    vComp = 1,
+                    xNome = "teste"
+                }
+            };
 
             #endregion
 

--- a/CTe.Classes/Informacoes/Complemento/Comp.cs
+++ b/CTe.Classes/Informacoes/Complemento/Comp.cs
@@ -30,14 +30,20 @@
 /* http://www.zeusautomacao.com.br/                                             */
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
+using DFe.Classes;
+
 namespace CTe.Classes.Informacoes.Complemento
 {
     public class Comp
     {
         private string _xNome;
-        private double _vComp;
+        private decimal _vComp;
 
         public string xNome { get { return _xNome; } set { _xNome = value; } }
-        public double vComp { get { return _vComp; } set { _vComp = value; } }
+        public decimal vComp
+        {
+            get { return _vComp.Arredondar(2); }
+            set { _vComp = value.Arredondar(2); }
+        }
     }
 }

--- a/CTe.Servicos/Enderecos/Helpers/UrlHelper.cs
+++ b/CTe.Servicos/Enderecos/Helpers/UrlHelper.cs
@@ -310,21 +310,6 @@ namespace CTe.Servicos.Enderecos.Helpers
                         QrCode = @"http://www.fazenda.pr.gov.br/cte/qrcode",
                         CTeDistribuicaoDFe = "https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
-                case Estado.RS:
-                    return new UrlCTe
-                    {
-                        CteStatusServico =
-                            @"https://cte.svrs.rs.gov.br/ws/ctestatusservico/CteStatusServico.asmx",
-                        CteRetRecepcao = @"https://cte.svrs.rs.gov.br/ws/cteretrecepcao/cteRetRecepcao.asmx",
-                        CteRecepcao = @"https://cte.svrs.rs.gov.br/ws/cterecepcao/CteRecepcao.asmx",
-                        CteInutilizacao =
-                            @"https://cte.svrs.rs.gov.br/ws/cteinutilizacao/cteinutilizacao.asmx",
-                        CteRecepcaoEvento =
-                            @"https://cte.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx",
-                        CteConsulta = @"https://cte.svrs.rs.gov.br/ws/cteconsulta/CteConsulta.asmx",
-                        QrCode = @"https://dfe-portal.svrs.rs.gov.br/cte/qrCode",
-                        CTeDistribuicaoDFe = "https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
-                    };
                 case Estado.SP:
                     if (configuracaoServico.VersaoLayout == versao.ve400)
                     {
@@ -373,6 +358,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                 case Estado.SC:
                 case Estado.SE:
                 case Estado.TO:
+                case Estado.RS:
                     if (configuracaoServico.VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
@@ -383,21 +369,21 @@ namespace CTe.Servicos.Enderecos.Helpers
                             CteStatusServico = @"https://cte.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx",
                             CteRecepcaoOs = @"https://cte.svrs.rs.gov.br/ws/CTeRecepcaoOSV4/CTeRecepcaoOSV4.asmx",
                             CteRecepcaoGtve = @"https://cte.svrs.rs.gov.br/ws/CTeRecepcaoGTVeV4/CTeRecepcaoGTVeV4.asmx",
-                            QrCode = @"https://dfe-portal.svrs.rs.gov.br/cte/qrCode"
+                            QrCode = @"https://dfe-portal.svrs.rs.gov.br/cte/qrCode",                            
                         };
                     }
 
                     return new UrlCTe
                     {
                         CteStatusServico =
-                            @"https://cte.svrs.rs.gov.br/ws/ctestatusservico/CteStatusServico.asmx",
-                        CteConsulta = @"https://cte.svrs.rs.gov.br/ws/cteconsulta/CteConsulta.asmx",
+                            @"https://cte.svrs.rs.gov.br/ws/ctestatusservico/CteStatusServico.asmx",                        
                         CteInutilizacao =
                             @"https://cte.svrs.rs.gov.br/ws/cteinutilizacao/cteinutilizacao.asmx",
                         CteRecepcao = @"https://cte.svrs.rs.gov.br/ws/cterecepcao/CteRecepcao.asmx",
                         CteRecepcaoEvento =
                             @"https://cte.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx",
                         CteRetRecepcao = @"https://cte.svrs.rs.gov.br/ws/cteretrecepcao/cteRetRecepcao.asmx",
+                        CteConsulta = @"https://cte.svrs.rs.gov.br/ws/cteconsulta/CteConsulta.asmx",
                         QrCode = @"https://dfe-portal.svrs.rs.gov.br/cte/qrCode",
                         CTeDistribuicaoDFe = "https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };


### PR DESCRIPTION
* soapaction invalido

* CRT no CTe-OS

* cte os

* autxml

* namespace do ctedadosmsg estava invalido para cte os, pegando do cte e na svrs estava retornando rejeicao 244

* a classe soapenvelop do cte ficou private e ocorre erro ao serializar o xml

* URL CTe Recepcao Sinc nao informada

* vComp do CTE-OS gerando com 1 casa decimal apos a virgula causando erro de schema

---------